### PR TITLE
Added HTTP basic auth

### DIFF
--- a/resources/lib/sickrage.py
+++ b/resources/lib/sickrage.py
@@ -1,4 +1,6 @@
 import urllib
+import urllib2
+import base64
 import socket
 import json
 
@@ -25,7 +27,13 @@ class API:
         params['cmd'] = cmd
         url = util.plugin.getSetting('url') + 'api/' + util.plugin.getSetting('key') + '/?' + urllib.urlencode(params)
         util.log('API: ' + url)
-        result = json.load(urllib.urlopen(url))
+        req = urllib2.Request(url)
+        user = util.plugin.getSetting('user')
+        password = util.plugin.getSetting('password')
+        if user and password:
+            auth = base64.encodestring('{}:{}'.format(user, password)).replace('\n', '')
+            req.add_header("Authorization", "Basic %s" % auth)        
+        result = json.load(urllib2.urlopen(req))
         #util.log(result)
         if result['result'] == 'denied':
             raise Exception('Access denied, check API Key.')

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -2,8 +2,12 @@
 <settings>
     <category label="API">
         <setting id="url" type="text" label="Sickrage URL" default="http://localhost:8081/"/>
-        <setting id="key" type="text" label="Sickrage API Key" default="" />
+        <setting id="key" type="text" label="Sickrage API Key" default=""/>
     </category>
+    <category label="Authentication">
+        <setting id="user" type="text" label="Username" default=""/>
+        <setting id="password" type="text" label="Password" default=""/>
+    </category>       
     <category label="Formats">
         <setting id="dateFormat" type="labelenum" label="Dates" values="M/D/Y|D/M/Y" default="M/D/Y"/>
         <setting id="timeFormat" type="labelenum" label="Times" values="AM/PM|24 Hour" default="AM/PM"/>


### PR DESCRIPTION
I added the option to use HTTP basic auth to enable this plugin to work over a reverse proxy.

The use case is that you use nginx to add HTTPS and basic authentication to sickrage to limit it's exposure to a select group of people.
