### PR TITLE
added arg to autosearch tvshow w/out keyboard input

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -28,6 +28,11 @@ try:
             util.log('invalid folder "' + vf + '"')
             import resources.lib.main as main
             main.menu()
+    elif 'title' in util.pluginArgs:
+        showtitle = util.pluginArgs['title']
+        print showtitle
+        import resources.lib.showAdd as showAdd
+        showAdd.action(showtitle)
     elif 'action' in util.pluginArgs:
         action = util.pluginArgs['action']
         if action == 'showAdd':
@@ -35,10 +40,10 @@ try:
             showAdd.action()
         else:
             util.log('invalid action "' + action + '"')
+
     else:
         import resources.lib.main as main
         main.menu()
 
 except IOError as ioe:
     util.message('Error', '%s' % ioe)
-    

--- a/resources/lib/showAdd.py
+++ b/resources/lib/showAdd.py
@@ -1,19 +1,24 @@
 import xbmc
 import xbmcgui
+import sys
 
 from operator import itemgetter
 
+
 import util as util
 
-def action():
-    
+def action(showtitle=None):
+
     # Get the name
-    
-    keyboard = xbmc.Keyboard('', 'Search for...', False)
-    keyboard.doModal()
-    if not keyboard.isConfirmed():
-        return
-    searchName = keyboard.getText() 
+    if showtitle is not None:
+        searchName = showtitle
+
+    else:
+        keyboard = xbmc.Keyboard('', 'Search for...', False)
+        keyboard.doModal()
+        if not keyboard.isConfirmed():
+            return
+        searchName = keyboard.getText()
 
     # Get indexer to use
     

--- a/resources/lib/sickrage.py
+++ b/resources/lib/sickrage.py
@@ -31,7 +31,7 @@ class API:
         user = util.plugin.getSetting('user')
         password = util.plugin.getSetting('password')
         if user and password:
-            auth = base64.encodestring('{}:{}'.format(user, password)).replace('\n', '')
+            auth = base64.encodestring('{0}:{1}'.format(user, password)).replace('\n', '')
             req.add_header("Authorization", "Basic %s" % auth)        
         result = json.load(urllib2.urlopen(req))
         #util.log(result)


### PR DESCRIPTION
adds the  option to run the plugin from inside the skin with an argument and pass the title of the tv show wanted, it can be picked from a list created for example by another addon (i.e. listed by phil's extendedinfo addon)

it works this way:
RunPlugin(plugin://plugin.program.sickrage?title=$INFO[ListItem.Label])

(of course I suck at python, so if this can be done in a better way... please do!)
